### PR TITLE
Fix sampling rate for ngs2 sound

### DIFF
--- a/modules/libSceNgs2/entry.cpp
+++ b/modules/libSceNgs2/entry.cpp
@@ -248,7 +248,7 @@ EXPORT SYSV_ABI int32_t sceNgs2SystemCreateWithAllocator(const SceNgs2SystemOpti
     return ret;
   }
 
-  *outh = new (cbi.hostBuffer) SceNgs2Handle_system(alloc);
+  *outh = new (cbi.hostBuffer) SceNgs2Handle_system(alloc, sysopt ? sysopt->sampleRate : 48000);
   getPimpl()->handles.emplace(*outh);
 
   LOG_DEBUG(L"-> System: 0x%08llx", (uint64_t)*outh);
@@ -263,8 +263,9 @@ EXPORT SYSV_ABI int32_t sceNgs2SystemCreate(const SceNgs2SystemOption* sysopt, c
   if (sysopt != nullptr && sysopt->size < sizeof(SceNgs2SystemOption)) return Err::Ngs2::INVALID_OPTION_SIZE;
   if (cbi == nullptr || cbi->hostBuffer == nullptr || cbi->hostBufferSize < sizeof(SceNgs2Handle)) return Err::Ngs2::INVALID_BUFFER_ADDRESS;
 
-  *outh = new (cbi->hostBuffer) SceNgs2Handle_system(nullptr);
-  getPimpl()->handles.emplace(*outh);
+  *outh = new (cbi->hostBuffer) SceNgs2Handle_system(nullptr, sysopt ? sysopt->sampleRate : 48000);
+
+  if (sysopt) getPimpl()->handles.emplace(*outh);
 
   LOG_DEBUG(L"-> System: 0x%08llx", (uint64_t)*outh);
   return (*outh) != nullptr ? Ok : Err::Ngs2::FAIL;

--- a/modules/libSceNgs2/entry.cpp
+++ b/modules/libSceNgs2/entry.cpp
@@ -582,7 +582,7 @@ EXPORT SYSV_ABI int32_t sceNgs2SystemRender(SceNgs2Handle* sysh, SceNgs2RenderBu
         std::memset(rbi[i].bufferPtr, 0, rbi[i].bufferSize);
         for (auto& voice: system->sampler->voices) {
           if (voice.second.reader != nullptr) {
-            // voice.second.reader->getAudio(&rbi[i], numSamples);
+            // voice.second.reader->getAudio(&rbi[i], numSamples, system->outSampleRate);
           }
         }
       }

--- a/modules/libSceNgs2/readFuncs.cpp
+++ b/modules/libSceNgs2/readFuncs.cpp
@@ -182,6 +182,7 @@ int32_t parseRiffWave(funcReadBuf_t readFunc, funcSeekBuf_t seekFunc, void* user
   return Ok;
 }
 
+// Output channel layout for everything >2.0 seems to be invalid, we need to rearrange those
 AVChannelLayout convChannelLayout(SceNgs2ChannelsCount count) {
   LOG_USE_MODULE(libSceNgs2);
   switch (count) {

--- a/modules/libSceNgs2/reader.cpp
+++ b/modules/libSceNgs2/reader.cpp
@@ -229,7 +229,7 @@ void Reader::setNewData(void const* start, void const* end) {
   voice->state.bits.Empty = false;
 }
 
-bool Reader::getAudioUncompressed(SceNgs2RenderBufferInfo* rbi, uint32_t numOutSamples) {
+bool Reader::getAudioUncompressed(SceNgs2RenderBufferInfo* rbi, uint32_t numOutSamples, uint32_t outRate) {
   LOG_USE_MODULE(libSceNgs2);
   auto pimpl = (PImpl*)m_pimpl;
 
@@ -249,8 +249,8 @@ bool Reader::getAudioUncompressed(SceNgs2RenderBufferInfo* rbi, uint32_t numOutS
     auto const [formatIn, bytesIn] = convFormat(voice->info.type);
     if (formatIn == AVSampleFormat::AV_SAMPLE_FMT_NONE) return false;
 
-    if (swr_alloc_set_opts2(&pimpl->swrCtx, &pimpl->curChannelLayoutOut, formatOut, voice->info.sampleRate, &pimpl->curChannelLayoutIn, formatIn,
-                            voice->info.sampleRate, 0, NULL)) {
+    if (swr_alloc_set_opts2(&pimpl->swrCtx, &pimpl->curChannelLayoutOut, formatOut, outRate, &pimpl->curChannelLayoutIn, formatIn, voice->info.sampleRate, 0,
+                            NULL)) {
       LOG_ERR(L"Reader:Couldn't alloc swr");
       return false;
     }
@@ -423,7 +423,7 @@ bool Reader::getAudioCompressed(SceNgs2RenderBufferInfo* rbi) {
   return true;
 }
 
-bool Reader::getAudio(SceNgs2RenderBufferInfo* rbi, uint32_t numOutSamples) {
+bool Reader::getAudio(SceNgs2RenderBufferInfo* rbi, uint32_t numOutSamples, uint32_t outRate) {
   if (m_isInit == false || voice->state.bits.Empty || !voice->state.bits.Playing || (voice->state.bits.Playing && voice->state.bits.Paused)) {
     return true;
   }
@@ -431,7 +431,7 @@ bool Reader::getAudio(SceNgs2RenderBufferInfo* rbi, uint32_t numOutSamples) {
   if (m_isCompressed) {
     return false; // getAudioCompressed(rbi);
   } else {
-    return getAudioUncompressed(rbi, numOutSamples);
+    return getAudioUncompressed(rbi, numOutSamples, outRate);
   }
   return true;
 }

--- a/modules/libSceNgs2/reader.h
+++ b/modules/libSceNgs2/reader.h
@@ -11,7 +11,7 @@ class Reader {
 
   SceNgs2SamplerVoiceState m_state;
 
-  bool getAudioUncompressed(SceNgs2RenderBufferInfo*, uint32_t numOutSamples);
+  bool getAudioUncompressed(SceNgs2RenderBufferInfo*, uint32_t numOutSamples, uint32_t outRate);
   bool getAudioCompressed(SceNgs2RenderBufferInfo*);
 
   public:
@@ -20,7 +20,7 @@ class Reader {
 
   bool init(SceNgs2SamplerVoiceWaveformBlocksParam const* param);
 
-  bool getAudio(SceNgs2RenderBufferInfo*, uint32_t numOutSamples);
+  bool getAudio(SceNgs2RenderBufferInfo*, uint32_t numOutSamples, uint32_t outRate);
 
   void setNewData(void const* start, void const* end);
 

--- a/modules/libSceNgs2/types.h
+++ b/modules/libSceNgs2/types.h
@@ -232,8 +232,14 @@ struct SceNgs2Handle_system: public SceNgs2Handle {
 
   // -
 
-  SceNgs2Handle_system(SceNgs2BufferAllocator const* alloc_): SceNgs2Handle(SceNgs2HandleType::System) {
+  // Options
+  uint32_t outSampleRate;
+
+  // -
+
+  SceNgs2Handle_system(SceNgs2BufferAllocator const* alloc_, uint32_t outrate): SceNgs2Handle(SceNgs2HandleType::System) {
     if (alloc_ != nullptr) alloc = *alloc_;
+    outSampleRate = outrate;
   }
 
   virtual ~SceNgs2Handle_system() = default;


### PR DESCRIPTION
Renderer should obey SystemOptions passed by the game to `sceNgs2SystemCreate*` functions